### PR TITLE
1.15.01d2

### DIFF
--- a/WTHLM/WTHLM_units.csv
+++ b/WTHLM/WTHLM_units.csv
@@ -7475,7 +7475,7 @@ fr_leopard_2a6nl_0;◘ Krauss-Maffei Wegmann | Gevechtstank, Rups, Leopard 2A6 N
 fr_leopard_2a6nl_1;◘ Leopard 2A6 NL
 fr_leopard_2a6nl_2;MBT
 fr_cv_9035_nl_shop;IGV 9035
-fr_cv_9035_nl_0;BAE Systems Hägglunds Combat Vehicle 9035NL | Infanteriegevechtsvoertuig, Pantser, Rups, IGV 9035, met kanon 35 mm
+fr_cv_9035_nl_0;BAE Systems Hägglunds Combat Vehicle 9035NL | Infanteriegevechtsvoertuig, Pantser, Rups, IGV 9035 met kanon 35 mm
 fr_cv_9035_nl_1;IGV 9035
 fr_cv_9035_nl_2;IFV
 

--- a/WTHLM/WTHLM_version.csv
+++ b/WTHLM/WTHLM_version.csv
@@ -1,5 +1,5 @@
 <ID|readonly|noverify>;<English>
-mainmenu/custom_lang_info;<color=@commonTextColor>War Tinder's Historical Localization Mod</color> <color=@goodTextColor>v1.15.01d1</color>
+mainmenu/custom_lang_info;<color=@commonTextColor>War Tinder's Historical Localization Mod</color> <color=@goodTextColor>v1.15.01d2</color>
 mainmenu/custom_lang_info/tooltip;"You have installed War Tinder's Historical Localization Mod <color=@goodTextColor>v1.15.01d1</color>. Vehicle, weapon, and modification names may appear different.
 
 If you find an error in the mod or a missing piece of text, please create a report in the issues section for the mod's GitHub repository. The GitHub repository can be found here:

--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ All dates are listed in DD-MM-YYYY format.
 
 - #### Changes:
 
-    - **CV9035NL** → **IGV 9035**.
+    - **CV9035NL** → **IGV 9035**. Statcard name → **BAE Systems Hägglunds Combat Vehicle 9035NL | Infanteriegevechtsvoertuig, Pantser, Rups, IGV 9035 met kanon 35 mm** (removed the accidental comma before "met").
     - **M44 / M55** (folder) (USA & France / Belgium) → **M44 / 55**. The French/Belgian folder's roundel has been corrected.
 
 ### Loading screens & profile backgrounds:


### PR DESCRIPTION
Removed accidental comma before 'met' in the IGV 9035's statcard name