### PR TITLE
Mandarin_1.00.00d160; Full_Ammo_Mandarin_1.00.00d21; Full_Mandarin_1.00.00d17; Full_Ammo_Full_Mandarin_1.00.00d3

### DIFF
--- a/packages/Package_Full_Ammo_Names_Full_Mandarin/WTHLM_units_weaponry_full_ammo_full_mandarin.csv
+++ b/packages/Package_Full_Ammo_Names_Full_Mandarin/WTHLM_units_weaponry_full_ammo_full_mandarin.csv
@@ -8,9 +8,9 @@
 //ROCKETS
 
 //MISSILES
-fb10_rocket;飞豹10地對空导弹
-fb10a_rocket;飞豹10A地對空导弹
-72mm_hn_6;红缨6地對空导弹
+fb10_rocket;飞豹-10地對空导弹
+fb10a_rocket;飞豹-10A地對空导弹
+72mm_hn_6;红缨-6地對空导弹
 
 //TORPEDOES
 

--- a/packages/Package_Full_Ammo_Names_Mandarin/WTHLM_units_weaponry_full_ammo_mandarin.csv
+++ b/packages/Package_Full_Ammo_Names_Mandarin/WTHLM_units_weaponry_full_ammo_mandarin.csv
@@ -1,13 +1,13 @@
 <ID|readonly|noverify>;<English>
 //AMMUNITION
-30mm_china_HE;CS/BAH06式30毫米杀伤爆破燃烧弹
+30mm_china_HE;CS/BAH06型30毫米杀伤爆破燃烧弹
 30mm_china_PTFP;CS/BAE5型30毫米定距预制破片弹
 30mm_zpz02_hei;DTY02式30毫米杀伤爆破燃烧弹
 30mm_zpz02_apds;DTC04式30毫米穿甲弹
 30mm_dtc10_30;DTC10式30毫米穿甲弹
 35mm_dkp_01a;DKG01A/PGZ09式35毫米穿甲爆破燃烧弹
 35mm_dkg_01a;DKP01A/PGZ09式35毫米杀伤爆破燃烧弹
-57mm_dky_1;DKY/PG87型57毫米杀伤爆破燃烧弹
+57mm_dky_1;DKY/PG59式57毫米杀伤爆破燃烧弹
 73mm_type_85_he;DYS73式73毫米钢珠杀伤榴弹
 73mm_type_85_heat;DYP73式73毫米破甲弹
 type_56_he;1956年式85毫米加农炮杀伤爆破榴弹
@@ -40,7 +40,7 @@ type_44_ap;1959年式100毫米坦克炮穿甲弹
 125mm_dtb_125;DTB式125毫米杀伤爆破榴弹
 125mm_dtb_12_he;DTB12式125毫米杀伤爆破榴弹
 125mm_dtp_125;DTP式125毫米破甲弹
-125mm_125_1;1985年-1式125毫米滑膛坦克炮脱壳超速穿甲弹
+125mm_125_1;1985年1式125毫米滑膛坦克炮脱壳超速穿甲弹
 125mm_dtw_125;DTW式125毫米穿甲弹
 125mm_dtc10_125;DTC10式125毫米穿甲弹
 125mm_bta4;BTA4型125毫米穿甲弹
@@ -56,11 +56,15 @@ type_44_ap;1959年式100毫米坦克炮穿甲弹
 155mm_bea_1;CS/BEA1型155毫米底排穿甲弹
 
 //MISSILES
-fb10_rocket;FB10地對空导弹
-fb10a_rocket;FB10A地對空导弹
+fb10_rocket;FB-10地對空导弹
+fb10a_rocket;FB-10A地對空导弹
 atgm_302;302反坦克导弹
 weapons/atgm_302/short;302
 152mm_hj9;AFT09重型反坦克导弹
+70mm_QN201DD;QN201经济型多用途导弹
+weapons/70mm_QN201DD/short;QN201
+151mm_QN502CDD;QN502C中程车载自寻的智能反坦克导弹
+weapons/151mm_qn502cdd/short;QN502C
 239mm_hq17;ADK17地對空导弹
 127mm_tc_1l;劍一飛彈
-72mm_hn_6;HN6地對空导弹
+72mm_hn_6;HN-6地對空导弹

--- a/packages/Package_Full_Mandarin/WTHLM_units_full_mandarin.csv
+++ b/packages/Package_Full_Mandarin/WTHLM_units_full_mandarin.csv
@@ -84,7 +84,7 @@ z_10a_2;直10
 
 //CHINA GROUND VEHICLES - VEHICLE/FAMILY START: RANK 6
 cn_hj_9_shop;AFT09
-cn_hj_9_0;中国兵器工业集团有限公司 | 红箭9 | AFT09重型反坦克导弹发射车
+cn_hj_9_0;中国兵器工业集团有限公司 | 红箭-9 | AFT09重型反坦克导弹发射车
 cn_hj_9_1;AFT09
 cn_hj_9_2;ATGMC
 
@@ -92,6 +92,6 @@ cn_hj_9_2;ATGMC
 
 //CHINA GROUND VEHICLES - VEHICLE/FAMILY START: RANK 8
 cn_hq_17_shop;ADK17
-cn_hq_17_0;中国精密机械进出口总公司 | 红旗17 | ADK17地對空导弹系統
+cn_hq_17_0;中国精密机械进出口总公司 | 红旗-17 | ADK17地對空导弹系統
 cn_hq_17_1;ADK17
 cn_hq_17_2;SPAAM

--- a/packages/Package_Full_Mandarin/WTHLM_units_weaponry_full_mandarin.csv
+++ b/packages/Package_Full_Mandarin/WTHLM_units_weaponry_full_mandarin.csv
@@ -10,66 +10,66 @@ weapons/cn_fs_70;火蛇70航空火箭弹 <color=#ff6f00>RKT</color>
 weapons/cn_fs_70/short;火蛇70
 
 //MISSILES
-weapons/su_pl2;霹雳2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl2;霹雳-2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl2/short;K/AKK2
-weapons/su_pl2_default;霹雳2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl2_default;霹雳-2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl2_default/short;K/AKK2
-weapons/su_pl5b;霹雳5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5b;霹雳-5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5b/short;K/AKK5B
-weapons/su_pl5b_default;霹雳5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5b_default;霹雳-5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5b_default/short;K/AKK5B
-weapons/su_pl5c;霹雳5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5c;霹雳-5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5c/short;K/AKK5C
-weapons/su_pl5c_default;霹雳5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5c_default;霹雳-5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5c_default/short;K/AKK5C
-weapons/su_pl5e2;霹雳5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5e2;霹雳-5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5e2/short;K/AKK5EII
-weapons/su_pl5e2_default;霹雳5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5e2_default;霹雳-5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5e2_default/short;K/AKK5EII
-weapons/su_pl7;霹雳7 | K/AKK7空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl7;霹雳-7 | K/AKK7空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl7/short;K/AKK7
-weapons/cn_pl8;霹雳8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8;霹雳-8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8/short;K/AKK8
-weapons/cn_pl8_default;霹雳8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8_default;霹雳-8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8_default/short;K/AKK8
-weapons/cn_pl8b;霹雳8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8b;霹雳-8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8b/short;K/AKK8B
-weapons/cn_pl8b_default;霹雳8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8b_default;霹雳-8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8b_default/short;K/AKK8B
-weapons/cn_pl11;霹雳11 | K/AKK11空空导弹 <color=#ff6f00>AAM-SARH</color>
+weapons/cn_pl11;霹雳-11 | K/AKK11空空导弹 <color=#ff6f00>AAM-SARH</color>
 weapons/cn_pl11/short;K/AKK11
-weapons/cn_pl12;霹雳12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
+weapons/cn_pl12;霹雳-12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
 weapons/cn_pl12/short;K/AKK12
-weapons/cn_pl12_default;霹雳12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
+weapons/cn_pl12_default;霹雳-12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
 weapons/cn_pl12_default/short;K/AKK12
-weapons/cn_ty_90;天燕90 | AKK90空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_ty_90;天燕-90 | AKK90空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_ty_90/short;AKK90
-weapons/cn_yj_81k;鹰击81 | H/AKJ08空舰导弹 <color=#ff6f00>AShM-ARH</color>
+weapons/cn_yj_81k;鹰击-81 | H/AKJ08空舰导弹 <color=#ff6f00>AShM-ARH</color>
 weapons/cn_yj_81k/short;H/AKJ08
-weapons/cn_hj_8a;红箭8A | AFT08A反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8a;红箭-8A | AFT08A反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8a/short;AFT08A
-weapons/cn_hj_8c;红箭8C | AFT08C反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8c;红箭-8C | AFT08C反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8c/short;AFT08C
-weapons/cn_hj_8e;红箭8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8e;红箭-8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8e/short;AFT08E
-weapons/cn_hj_8e_default;红箭8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8e_default;红箭-8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8e_default/short;AFT08E
-weapons/cn_hj_8h;红箭8H | AFT08H反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8h;红箭-8H | AFT08H反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8h/short;AFT08H
-weapons/cn_hj_8l;红箭8L | AFT08L反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8l;红箭-8L | AFT08L反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8l/short;AFT08L
-weapons/125mm_hj_73_rocket_launcher;红箭73 | AFT07反坦克导弹 <color=#ff6f00>LCH</color>
+weapons/125mm_hj_73_rocket_launcher;红箭-73 | AFT07反坦克导弹 <color=#ff6f00>LCH</color>
 weapons/125mm_hj_73_rocket_launcher/short;AFT07
-weapons/125mm_AFT_07_rocket_launcher;红箭73E | AFT07E反坦克导弹 <color=#ff6f00>LCH</color>
+weapons/125mm_AFT_07_rocket_launcher;红箭-73E | AFT07E反坦克导弹 <color=#ff6f00>LCH</color>
 weapons/125mm_AFT_07_rocket_launcher/short;AFT07E
-weapons/152mm_hj_9_launcher_user_cannon;红箭9 | AFT09重型反坦克导弹发射车 <color=#ff6f00>LCH</color>
-fb10_rocket;飞豹10
-fb10a_rocket;飞豹10A
-weapons/130mm_FB_10_rocket_launcher;飞豹10地對空导弹发射器 <color=#ff6f00>LCH</color>
-weapons/239mm_HQ_17_user_cannon;红旗17 | ADK17地對空导弹系統 <color=#ff6f00>LCH</color>
-weapons/72mm_HN_6_launcher_user_cannon;红缨6地對空导弹发射器 <color=#ff6f00>LCH</color>
-72mm_hn_6;红缨6
-weapons/72mm_hn_6/short;红缨6
+weapons/152mm_hj_9_launcher_user_cannon;红箭-9 | AFT09重型反坦克导弹发射车 <color=#ff6f00>LCH</color>
+fb10_rocket;飞豹-10
+fb10a_rocket;飞豹-10A
+weapons/130mm_FB_10_rocket_launcher;飞豹-10地對空导弹发射架 <color=#ff6f00>LCH</color>
+weapons/239mm_HQ_17_user_cannon;红旗-17 | ADK17地對空导弹系統 <color=#ff6f00>LCH</color>
+weapons/72mm_HN_6_launcher_user_cannon;红缨-6地對空导弹发射架 <color=#ff6f00>LCH</color>
+72mm_hn_6;红缨-6
+weapons/72mm_hn_6/short;红缨-6
 
 //TORPEDOES
 

--- a/packages/Package_Mandarin/WTHLM_units_mandarin.csv
+++ b/packages/Package_Mandarin/WTHLM_units_mandarin.csv
@@ -612,12 +612,12 @@ cn_type_69_shop;ZTZ69
 cn_type_69_0;内蒙古第一机械制造厂 | WZ121 | ZTZ1969式中型坦克
 cn_type_69_1;ZTZ69
 cn_type_69_2;Medium Tank
-cn_type_69_2a_shop;Type 69-IIA
-cn_type_69_2a_0;中国兵器工业集团有限公司 | BW121A | Type 69-IIA Main Battle Tank
-cn_type_69_2a_1;Type 69-IIA
+cn_type_69_2a_shop;69-II
+cn_type_69_2a_0;中国兵器工业集团有限公司 | BW121A | 69-II主战坦克
+cn_type_69_2a_1;69-II
 cn_type_69_2a_2;Medium Tank
 cn_wz_305_shop;80式
-cn_wz_305_0;中国兵器工业集团有限公司 | WZ305 | 1980年式双57毫米自行高炮
+cn_wz_305_0;中国兵器工业集团有限公司 | W305 | 1980年式双管57毫米自行高射炮
 cn_wz_305_1;80式
 cn_wz_305_2;SPAAG
 cn_plz_05_shop;PLZ05
@@ -679,7 +679,7 @@ cn_ptl_02_0;中国兵器工业集团有限公司 | WA301 | PTL2002式100毫米�
 cn_ptl_02_1;PTL02
 cn_ptl_02_2;Light Tank
 cn_hj_9_shop;AFT09
-cn_hj_9_0;中国兵器工业集团有限公司 | HJ9 | AFT09重型反坦克导弹发射车
+cn_hj_9_0;中国兵器工业集团有限公司 | HJ-9 | AFT09重型反坦克导弹发射车
 cn_hj_9_1;AFT09
 cn_hj_9_2;ATGMC
 cn_cm_34_shop;CM34
@@ -755,7 +755,7 @@ cn_tor_m1_0;"␗ Naučno-proizvodstvyennoye ob""yedinyeniye Antyej | BM 9A331-1"
 cn_tor_m1_1;␗ 9A331-1
 cn_tor_m1_2;SPAAM
 cn_hq_17_shop;ADK17
-cn_hq_17_0;中国精密机械进出口总公司 | HQ17 | ADK17地對空导弹系統
+cn_hq_17_0;中国精密机械进出口总公司 | HQ-17 | ADK17地對空导弹系統
 cn_hq_17_1;ADK17
 cn_hq_17_2;SPAAM
 cn_pgz_625_fb10_shop;CS/SA5 (2022)

--- a/packages/Package_Mandarin/WTHLM_units_weaponry_mandarin.csv
+++ b/packages/Package_Mandarin/WTHLM_units_weaponry_mandarin.csv
@@ -34,8 +34,8 @@ weapons/85mm_Type_62_85_TC_user_cannon;<color=@userlogColoredText>85 mm</color> 
 weapons/85mm_Type_63_user_cannon;<color=@userlogColoredText>85 mm</color> 1963年式85毫米坦克炮 <color=#ff6f00>CNN</color>
 weapons/100mm_PTP86_user_cannon;<color=@userlogColoredText>100 mm</color> WA301 | PTL2002式100毫米轮式自行突击炮 <color=#ff6f00>CNN</color>
 weapons/100mm_Type59_user_cannon;<color=@userlogColoredText>100 mm</color> 1959年式100毫米坦克炮 <color=#ff6f00>CNN</color>
-weapons/100mm_Type69_user_cannon;<color=@userlogColoredText>100 mm</color> 1969年式100毫米坦克炮 <color=#ff6f00>CNN</color>
-weapons/100mm_Type69_II_user_cannon;<color=@userlogColoredText>100 mm</color> Type 69-II 100 mm Tank Gun <color=#ff6f00>CNN</color>
+weapons/100mm_Type69_user_cannon;<color=@userlogColoredText>100 mm</color> 1969年式100毫米滑膛坦克炮 <color=#ff6f00>CNN</color>
+weapons/100mm_Type69_II_user_cannon;<color=@userlogColoredText>100 mm</color> 69-II型100毫米坦克炮 <color=#ff6f00>CNN</color>
 weapons/100mm_2a70_zbd_user_cannon;<color=@userlogColoredText>100 mm</color> ZPL2004式100毫米坦克炮 <color=#ff6f00>CNN-LCH</color>
 weapons/105mm_type_75_user_cannon;<color=@userlogColoredText>105 mm</color> PW1975式105毫米无后坐力炮 <color=#ff6f00>CNN-RCL</color>
 weapons/105mm_Type_83_user_cannon;<color=@userlogColoredText>105 mm</color> 1983年式105毫米坦克炮 <color=#ff6f00>CNN</color>
@@ -62,7 +62,7 @@ weapons/155mm_PL05_user_cannon;<color=@userlogColoredText>155 mm</color> PLZ2005
 30mm_dtc10_30;DTC10-30
 35mm_dkp_01a;DKG01A/PGZ09-35
 35mm_dkg_01a;DKP01A/PGZ09-35
-57mm_dky_1;DKY/PG87-57
+57mm_dky_1;DKY/PG59-57
 73mm_type_85_he;DYS73-73
 73mm_type_85_heat;DYP73-73
 type_56_he;56式85毫米杀爆榴弹
@@ -163,39 +163,39 @@ weapons/cn_type130_ap;130毫米1型航空火箭杀伤爆破弹 <color=#ff6f00>RK
 weapons/cn_type130_ap/short;130-1型
 
 //MISSILES
-weapons/su_pl2;PL2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl2;PL-2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl2/short;K/AKK2
-weapons/su_pl2_default;PL2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl2_default;PL-2 | K/AKK2空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl2_default/short;K/AKK2
-weapons/su_pl5b;PL5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5b;PL-5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5b/short;K/AKK5B
-weapons/su_pl5b_default;PL5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5b_default;PL-5B | K/AKK5B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5b_default/short;K/AKK5B
-weapons/su_pl5c;PL5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5c;PL-5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5c/short;K/AKK5C
-weapons/su_pl5c_default;PL5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5c_default;PL-5C | K/AKK5C空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5c_default/short;K/AKK5C
-weapons/su_pl5e2;PL5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5e2;PL-5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5e2/short;K/AKK5EII
-weapons/su_pl5e2_default;PL5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl5e2_default;PL-5EII | K/AKK5EII空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl5e2_default/short;K/AKK5EII
-weapons/su_pl7;PL7 | K/AKK7空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl7;PL-7 | K/AKK7空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl7/short;K/AKK7
-weapons/su_pl8;PL8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl8;PL-8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl8/short;K/AKK8
-weapons/su_pl8_default;PL8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/su_pl8_default;PL-8 | K/AKK8空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/su_pl8_default/short;K/AKK8
-weapons/cn_pl8b;PL8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8b;PL-8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8b/short;K/AKK8B
-weapons/cn_pl8b_default;PL8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_pl8b_default;PL-8B | K/AKK8B空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_pl8b_default/short;K/AKK8B
-weapons/cn_pl11;PL11 | K/AKK11空空导弹 <color=#ff6f00>AAM-SARH</color>
+weapons/cn_pl11;PL-11 | K/AKK11空空导弹 <color=#ff6f00>AAM-SARH</color>
 weapons/cn_pl11/short;K/AKK11
-weapons/cn_pl12;PL12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
+weapons/cn_pl12;PL-12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
 weapons/cn_pl12/short;K/AKK12
-weapons/cn_pl12_default;PL12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
+weapons/cn_pl12_default;PL-12 | K/AKK12空空导弹 <color=#ff6f00>AAM-ARH</color>
 weapons/cn_pl12_default/short;K/AKK12
-weapons/cn_ty_90;TY90 | AKK90空空导弹 <color=#ff6f00>AAM-IR</color>
+weapons/cn_ty_90;TY-90 | AKK90空空导弹 <color=#ff6f00>AAM-IR</color>
 weapons/cn_ty_90/short;AKK90
 weapons/cn_akd_9;AKD09空地导弹 <color=#ff6f00>AGM-LG</color>
 weapons/cn_akd_9/short;AKD09
@@ -205,27 +205,27 @@ weapons/cn_ba_9;AKD09空地导弹 <color=#ff6f00>AGM-LG</color>
 weapons/cn_ba_9/short;AKD09
 weapons/cn_akd_10;AKD10空地导弹 <color=#ff6f00>AGM-LG</color>
 weapons/cn_akd_10/short;AKD10
-weapons/cn_yj_81k;YJ81 | H/AKJ08空舰导弹 <color=#ff6f00>AShM-ARH</color>
+weapons/cn_yj_81k;YJ-81 | H/AKJ08空舰导弹 <color=#ff6f00>AShM-ARH</color>
 weapons/cn_yj_81k/short;H/AKJ08
-weapons/cn_hj_8a;HJ8A | AFT08A反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8a;HJ-8A | AFT08A反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8a/short;AFT08A
-weapons/cn_hj_8c;HJ8C | AFT08C反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8c;HJ-8C | AFT08C反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8c/short;AFT08C
-weapons/cn_hj_8e;HJ8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8e;HJ-8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8e/short;AFT08E
-weapons/cn_hj_8e_default;HJ8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8e_default;HJ-8E | AFT08E反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8e_default/short;AFT08E
-weapons/cn_hj_8h;HJ8H | AFT08H反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8h;HJ-8H | AFT08H反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8h/short;AFT08H
-weapons/cn_hj_8l;HJ8L | AFT08L反坦克导弹 <color=#ff6f00>AGM-WG</color>
+weapons/cn_hj_8l;HJ-8L | AFT08L反坦克导弹 <color=#ff6f00>AGM-WG</color>
 weapons/cn_hj_8l/short;AFT08L
 weapons/cn_cm_502kg_he;CM502KG轻型近程空面导弹武器系统 <color=#ff6f00>AGM-IR</color>
 weapons/cn_cm_502kg_he/short;CM502KG
 weapons/cn_cm_502kg_he_rail;CM502KG轻型近程空面导弹武器系统 <color=#ff6f00>AGM-IR</color>
 weapons/cn_cm_502kg_he_rail/short;CM502KG
-weapons/125mm_hj_73_rocket_launcher;HJ73 | AFT07反坦克导弹 <color=#ff6f00>LCH</color>
+weapons/125mm_hj_73_rocket_launcher;HJ-73 | AFT07反坦克导弹 <color=#ff6f00>LCH</color>
 weapons/125mm_hj_73_rocket_launcher/short;AFT07
-weapons/125mm_AFT_07_rocket_launcher;HJ73E | AFT07E反坦克导弹 <color=#ff6f00>LCH</color>
+weapons/125mm_AFT_07_rocket_launcher;HJ-73E | AFT07E反坦克导弹 <color=#ff6f00>LCH</color>
 weapons/125mm_AFT_07_rocket_launcher/short;AFT07E
 125mm_hj_73;AFT07
 weapons/125mm_hj_73/short;AFT07
@@ -237,13 +237,21 @@ weapons/120mm_302_atgm_rocket_launcher;302反坦克导弹 <color=#ff6f00>LCH</co
 weapons/120mm_302_atgm_rocket_launcher/short;302
 atgm_302;302
 weapons/atgm_302/short;302
-weapons/152mm_hj_9_launcher_user_cannon;HJ9 | AFT09重型反坦克导弹发射车 <color=#ff6f00>LCH</color>
+weapons/152mm_hj_9_launcher_user_cannon;HJ-9 | AFT09重型反坦克导弹发射车 <color=#ff6f00>LCH</color>
 152mm_hj9;AFT09
-weapons/130mm_FB_10_rocket_launcher;FB10地對空导弹发射器 <color=#ff6f00>LCH</color>
-weapons/72mm_HN_6_launcher_user_cannon;HN6地對空导弹发射器 <color=#ff6f00>LCH</color>
-72mm_hn_6;HN6
-weapons/72mm_hn_6/short;HN6
-weapons/239mm_HQ_17_user_cannon;HQ17 | ADK17地對空导弹系統 <color=#ff6f00>LCH</color>
+weapons/70mm_QN201DD_rocket_launcher;QN201经济型多用途导弹发射架 <color=#ff6f00>LCH</color>
+weapons/70mm_QN201DD_rocket_launcher/short;QN201
+70mm_QN201DD;QN201
+weapons/70mm_QN201DD/short;QN201
+weapons/151mm_QN502CDD_rocket_launcher;QN502C中程车载自寻的智能反坦克导弹发射架 <color=#ff6f00>LCH</color>
+weapons/151mm_QN502CDD_rocket_launcher/short;QN502C
+151mm_QN502CDD;QN502C
+weapons/151mm_qn502cdd/short;QN502C
+weapons/130mm_FB_10_rocket_launcher;FB-10地對空导弹发射架 <color=#ff6f00>LCH</color>
+weapons/72mm_HN_6_launcher_user_cannon;HN-6地對空导弹发射架 <color=#ff6f00>LCH</color>
+72mm_hn_6;HN-6
+weapons/72mm_hn_6/short;HN-6
+weapons/239mm_HQ_17_user_cannon;HQ-17 | ADK17地對空导弹系統 <color=#ff6f00>LCH</color>
 239mm_hq17;ADK17
 weapons/239mm_hq17/short;ADK17
 weapons/127mm_tc_1l_rocket_launcher_user_cannon;劍一防空飛彈系統 <color=#ff6f00>LCH</color>


### PR DESCRIPTION
Missiles, ammo, added a '-' to the old 2 letter code names (most but not all), 69-II, Type 80 changes.